### PR TITLE
turned off optimiser by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ var compile = function(sources, options, callback) {
   // Add the listener back in, just in case I need it.
   process.on("uncaughtException", solc_listener);
 
-  var result = solc.compile({sources: operatingSystemIndependentSources}, 1);
+  var result = solc.compile({sources: operatingSystemIndependentSources}, 0);
 
   // Alright, now remove it.
   process.removeListener("uncaughtException", solc_listener);


### PR DESCRIPTION
The optimiser of solc compiler has been the source of several rather serious bugs:
e.g. https://www.reddit.com/r/ethereum/comments/5fvpjq/psa_beware_of_buggy_solidity_version/

Given the current experimental nature of Ethereum, I'd advise for turning of the optimiser by default, or at least to implement a way to config it in truffle.js

This PR turns off the optimiser by default.