### PR TITLE
Make truffle-compile better for bundling

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ var solc = require("solc");
 // Clean up after solc.
 var listeners = process.listeners("uncaughtException");
 var solc_listener = listeners[listeners.length - 1];
-process.removeListener("uncaughtException", solc_listener);
+
+if (solc_listener) {
+  process.removeListener("uncaughtException", solc_listener);
+}
 
 var path = require("path");
 var fs = require("fs");
@@ -58,9 +61,6 @@ var compile = function(sources, options, callback) {
     operatingSystemIndependentSources[replacement] = sources[source];
   });
 
-  // Add the listener back in, just in case I need it.
-  process.on("uncaughtException", solc_listener);
-
   var solcStandardInput = {
     language: "Solidity",
     sources: {},
@@ -96,9 +96,6 @@ var compile = function(sources, options, callback) {
   });
 
   var result = solc.compileStandard(JSON.stringify(solcStandardInput));
-
-  // Alright, now remove it.
-  process.removeListener("uncaughtException", solc_listener);
 
   var standardOutput = JSON.parse(result);
 


### PR DESCRIPTION
- There is no uncaughtException listener in bundled land, it looks
like, so removing the listener that solc adds fails when bundled. To
get around this, add a conditional check to ensure the listener exists.

- F this listener noise. solc doesn’t use the listener anyway (it’s
added by emscripten), so stop trying to manage its existence “just in
case”

(FYI, for background: This listener needs to be removed in a NodeJS
environment because the listener will rethrow all errors making output
really nasty. We don’t need that behavior, hence why the listener is
removed immediately.)