### PR TITLE
Fix for issue #445

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,18 @@ var compile = function(sources, options, callback) {
     }
   });
 
+  if (options.parse){
+    const SolidityParser = require("solidity-parser");
+    Object.keys(operatingSystemIndependentSources).forEach(function(file_path) {
+      try {
+        var source = operatingSystemIndependentSources[file_path];
+        SolidityParser.parse(source);
+      } catch (e) {
+        console.log("WARNING:  Parsing error in " + file_path + ":\n" + e.message);
+      }
+    });
+  }
+
   var result = solc.compileStandard(JSON.stringify(solcStandardInput));
 
   var standardOutput = JSON.parse(result);


### PR DESCRIPTION
Added a --parse flag to truffle compile	
  - allows you to see syntax errors per file
  - now if solc craps out, you know more than "5 5"