### PR TITLE
Upgrade broken dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "graphlib": "^2.1.1",
     "solc": "0.4.11",
     "solidity-parser": "^0.3.0",
-    "truffle-config": "0.0.7",
+    "truffle-config": "^1.0.0",
     "truffle-contract-sources": "^0.0.1",
     "truffle-error": "0.0.2",
     "truffle-expect": "0.0.3"
   },
   "devDependencies": {
-    "truffle-resolver": "2.0.0"
+    "truffle-resolver": "^3.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-compile",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Compiler helper and artifact manager",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-compile",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "Compiler helper and artifact manager",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/trufflesuite/truffle-compile/issues/11

Upgraded:
- [truffle-config](https://github.com/trufflesuite/truffle-config) to ^1.0.0. Depends on hotfix for https://github.com/trufflesuite/truffle-config/issues/2
- [truffle-resolver](https://github.com/trufflesuite/truffle-resolver) to ^3.0.0. Depends on hotfix for broken transitive dependency [truffle-config](https://github.com/trufflesuite/truffle-contract) due to https://github.com/trufflesuite/truffle-contract/issues/31