### PR TITLE
Allow project configuration to specify compilation settings to solc

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ var compile = function(sources, options, callback) {
   }
 
   expect.options(options, [
-    "contracts_directory"
+    "contracts_directory",
+    "solc"
   ]);
 
   // Ensure sources have operating system independent paths
@@ -83,6 +84,9 @@ var compile = function(sources, options, callback) {
       }
     }
   };
+
+  // merge solc settings specified in truffle config
+  Object.assign(solcStandardInput.settings, options.solc);
 
   // Nothing to compile? Bail.
   if (Object.keys(sources).length == 0) {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ var compile = function(sources, options, callback) {
     language: "Solidity",
     sources: {},
     settings: {
+      optimizer: options.solc.optimizer,
       outputSelection: {
         "*": {
           "*": [
@@ -80,9 +81,6 @@ var compile = function(sources, options, callback) {
       }
     }
   };
-
-  // merge solc settings specified in truffle config
-  Object.assign(solcStandardInput.settings, options.solc);
 
   // Nothing to compile? Bail.
   if (Object.keys(sources).length == 0) {

--- a/index.js
+++ b/index.js
@@ -66,10 +66,6 @@ var compile = function(sources, options, callback) {
     language: "Solidity",
     sources: {},
     settings: {
-      optimizer: {
-        enabled: true,
-        runs: 0 // See https://github.com/ethereum/solidity/issues/2245
-      },
       outputSelection: {
         "*": {
           "*": [


### PR DESCRIPTION
Ref: trufflesuite/truffle#486

- Respect `solc` config option, pass as part of standard input
- Remove the `optimizer` settings from the solc standard input literal (config concern now)