### PR TITLE
Update solidity-parser to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "colors": "^1.1.2",
     "graphlib": "^2.1.1",
     "solc": "0.4.15",
-    "solidity-parser": "^0.3.0",
+    "solidity-parser": "^0.4.0",
     "truffle-config": "^1.0.2",
     "truffle-contract-sources": "^0.0.1",
     "truffle-error": "^0.0.2",


### PR DESCRIPTION
This adds support for the `interface` keyword.