### PR TITLE
Remove solidity parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "colors": "^1.1.2",
     "graphlib": "^2.1.1",
     "solc": "0.4.15",
-    "solidity-parser": "^0.4.0",
     "truffle-config": "^1.0.2",
     "truffle-contract-sources": "^0.0.1",
     "truffle-error": "^0.0.2",
     "truffle-expect": "^0.0.3"
   },
   "devDependencies": {
+    "mocha": "^3.5.3",
     "truffle-resolver": "2.0.0"
   },
   "scripts": {

--- a/parser.js
+++ b/parser.js
@@ -72,13 +72,13 @@ module.exports = {
     var solcStandardInput = {
       language: "Solidity",
       sources: {
-        "Contract.sol": {
+        "ParsedContract.sol": {
           content: body
         }
       },
       settings: {
         outputSelection: {
-          "Contract.sol": {
+          "ParsedContract.sol": {
             "*": [] // We don't need any output.
           }
         }
@@ -96,6 +96,7 @@ module.exports = {
     var nonImportErrors = output.errors.filter(function(solidity_error) {
       // If the import error key is not found, we must not have an import error. 
       // This means we have a *different* parsing error which we should show to the user.
+      // Note: solc can return multiple parsing errors at once.
       return solidity_error.formattedMessage.indexOf(importErrorKey) < 0;
     });
     

--- a/parser.js
+++ b/parser.js
@@ -26,7 +26,7 @@ module.exports = {
       },
       settings: {
         outputSelection: {
-          "Contract.sol": {
+          [fileName]: {
             "*": ["ast"] 
           }
         }
@@ -87,7 +87,7 @@ module.exports = {
 
     var output = solc.compileStandard(JSON.stringify(solcStandardInput), function() {
       // The existence of this function ensures we get a parsable error message.
-      // TRUFFLE_IMPORT lets us make a nice, detectable error. 
+      // Without this, we'll get an error message we can detect, but the key make it easier. 
       return {error: importErrorKey};
     });
 
@@ -95,6 +95,7 @@ module.exports = {
 
     var nonImportErrors = output.errors.filter(function(solidity_error) {
       // If the import error key is not found, we must not have an import error. 
+      // This means we have a *different* parsing error which we should show to the user.
       return solidity_error.formattedMessage.indexOf(importErrorKey) < 0;
     });
     

--- a/parser.js
+++ b/parser.js
@@ -89,7 +89,7 @@ module.exports = {
 
     var output = solc.compileStandard(JSON.stringify(solcStandardInput), function() {
       // The existence of this function ensures we get a parsable error message.
-      // Without this, we'll get an error message we can detect, but the key make it easier. 
+      // Without this, we'll get an error message we *can* detect, but the key will make it easier. 
       // Note: This is not a normal callback. See docs here: https://github.com/ethereum/solc-js#from-version-021
       return {error: importErrorKey};
     });

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,119 @@
+var CompileError = require("./compileerror");
+var solc = require("solc");
+
+// Clean up after solc.
+var listeners = process.listeners("uncaughtException");
+var solc_listener = listeners[listeners.length - 1];
+
+if (solc_listener) {
+  process.removeListener("uncaughtException", solc_listener);
+}
+
+module.exports = {
+  parse: function(body, fileName) {
+    // Here, we want a valid AST even if imports don't exist. The way to
+    // get around that is to tell the compiler, as they happen, that we 
+    // have source for them (an empty file).
+
+    var fileName = fileName || "ParsedContract.sol";
+
+    var solcStandardInput = {
+      language: "Solidity",
+      sources: {
+        [fileName]: {
+          content: body
+        }
+      },
+      settings: {
+        outputSelection: {
+          "Contract.sol": {
+            "*": ["ast"] 
+          }
+        }
+      }
+    };
+
+    var output = solc.compileStandard(JSON.stringify(solcStandardInput), function(file_path) {
+      // Tell the compiler we have source code for the dependency
+      return {contents: "pragma solidity ^0.4.0;"};
+    });
+
+    output = JSON.parse(output);
+
+    if (output.errors) {
+      throw new CompileError(output.errors[0].formattedMessage);
+    }
+
+    return {
+      contracts: Object.keys(output.contracts[fileName]),
+      ast: output.sources[fileName].ast
+    };
+  },
+
+  // This needs to be fast! It is fast (as of this writing). Keep it fast!
+  parseImports: function(body) {
+    var self = this;
+    
+    // So we don't have to maintain a separate parser, we'll get all the imports
+    // in a file by sending the file to solc and evaluating the error messages 
+    // to see what import statements couldn't be resolved. To prevent full-on
+    // compilation when a file has no import statements, we inject an import
+    // statement right on the end; just to ensure it will error and we can parse
+    // the imports speedily without doing extra work.
+
+    // Helper to detect import errors with an easy regex. 
+    var importErrorKey = "TRUFFLE_IMPORT";
+
+    // Inject failing import.
+    var failingImportFileName = "__Truffle__NotFound.sol";
+    
+    body = body + "\n\nimport '" + failingImportFileName + "';\n";
+
+    var solcStandardInput = {
+      language: "Solidity",
+      sources: {
+        "Contract.sol": {
+          content: body
+        }
+      },
+      settings: {
+        outputSelection: {
+          "Contract.sol": {
+            "*": [] // We don't need any output.
+          }
+        }
+      }
+    };
+
+    var output = solc.compileStandard(JSON.stringify(solcStandardInput), function() {
+      // The existence of this function ensures we get a parsable error message.
+      // TRUFFLE_IMPORT lets us make a nice, detectable error. 
+      return {error: importErrorKey};
+    });
+
+    output = JSON.parse(output);
+
+    var nonImportErrors = output.errors.filter(function(solidity_error) {
+      // If the import error key is not found, we must not have an import error. 
+      return solidity_error.formattedMessage.indexOf(importErrorKey) < 0;
+    });
+    
+    // Should we try to throw more than one? (aside; we didn't before)
+    if (nonImportErrors.length > 0) {
+      throw new CompileError(nonImportErrors[0].formattedMessage);
+    }
+
+    // Now, all errors must be import errors. 
+    // Filter out our forced import, then get the import paths of the rest.
+    var imports = output.errors.filter(function(solidity_error) {
+      return solidity_error.message.indexOf(failingImportFileName) < 0;
+    }).map(function(solidity_error) {
+      var matches = solidity_error.formattedMessage.match(/import ("|')([^'"]+)("|');/);
+
+      // Return the item between the quotes.
+      return matches[2];
+    });
+
+    return imports;
+  }
+}

--- a/parser.js
+++ b/parser.js
@@ -53,6 +53,8 @@ module.exports = {
   // This needs to be fast! It is fast (as of this writing). Keep it fast!
   parseImports: function(body) {
     var self = this;
+
+    // WARNING: Kind of a hack (an expedient one).
     
     // So we don't have to maintain a separate parser, we'll get all the imports
     // in a file by sending the file to solc and evaluating the error messages 
@@ -88,6 +90,7 @@ module.exports = {
     var output = solc.compileStandard(JSON.stringify(solcStandardInput), function() {
       // The existence of this function ensures we get a parsable error message.
       // Without this, we'll get an error message we can detect, but the key make it easier. 
+      // Note: This is not a normal callback. See docs here: https://github.com/ethereum/solc-js#from-version-021
       return {error: importErrorKey};
     });
 

--- a/test/MyContract.sol
+++ b/test/MyContract.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.15;
+
+import "./Dependency.sol";
+import "./path/to/AnotherDep.sol";
+import "../../../path/to/AnotherDep.sol";
+import "ethpmpackage/Contract.sol";
+
+contract MyContract {
+
+}
+
+library SomeLibrary {
+
+}
+
+interface SomeInterface {
+
+}

--- a/test/ShouldError.sol
+++ b/test/ShouldError.sol
@@ -1,0 +1,5 @@
+paragma solidity ^0.4.0;
+
+contract Error {
+  
+}

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -5,9 +5,11 @@ var assert = require("assert");
 
 describe("Parser", function() {
   var source = null;
+  var erroneousSource = null;
 
   before("get code", function() {
     source = fs.readFileSync(path.join(__dirname, "MyContract.sol"), "utf-8");
+    erroneousSource = fs.readFileSync(path.join(__dirname, "ShouldError.sol"), "utf-8");
   });
 
   it("should return correct imports", function() {
@@ -26,6 +28,21 @@ describe("Parser", function() {
     assert.deepEqual(imports, expected)
   });
 
+  it("should throw an error when parsing imports if there's an actual parse error", function() {
+    var error = null;
+    try {
+      Parser.parseImports(erroneousSource);
+    } catch(e) {
+      error = e;
+    }
+
+    if (!error) {
+      throw new Error("Expected a parse error but didn't get one!");
+    }
+
+    assert(error.message.indexOf("Expected pragma, import directive or contract") >= 0);
+  });
+
   it("should return a full AST when parsed, even when dependencies don't exist", function() {
     this.timeout(4000);
 
@@ -36,5 +53,20 @@ describe("Parser", function() {
     
     // The above assert means we at least got some kind of AST.
     // Is there something we specifically need here? 
+  });
+
+  it("should throw an error when parsing completely if there's an actual parse error", function() {
+    var error = null;
+    try {
+      Parser.parse(erroneousSource);
+    } catch(e) {
+      error = e;
+    }
+
+    if (!error) {
+      throw new Error("Expected a parse error but didn't get one!");
+    }
+
+    assert(error.message.indexOf("Expected pragma, import directive or contract") >= 0);
   });
 });

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -1,0 +1,40 @@
+var fs = require("fs");
+var path = require("path");
+var Parser = require("../parser");
+var assert = require("assert");
+
+describe("Parser", function() {
+  var source = null;
+
+  before("get code", function() {
+    source = fs.readFileSync(path.join(__dirname, "MyContract.sol"), "utf-8");
+  });
+
+  it("should return correct imports", function() {
+    var imports = Parser.parseImports(source);
+
+    // Note that this test is important because certain parts of the solidity
+    // output cuts off path prefixes like "./" and "../../../". If we get the
+    // imports list incorrectly, we'll have collisions. 
+    var expected = [ 
+      './Dependency.sol',
+      './path/to/AnotherDep.sol',
+      '../../../path/to/AnotherDep.sol',
+      'ethpmpackage/Contract.sol' 
+    ];
+
+    assert.deepEqual(imports, expected)
+  });
+
+  it("should return a full AST when parsed, even when dependencies don't exist", function() {
+    this.timeout(4000);
+
+    var output = Parser.parse(source);
+
+    assert.deepEqual(output.contracts, ["MyContract", "SomeInterface", "SomeLibrary"]);
+    assert(output.ast.nodes.length > 0); 
+    
+    // The above assert means we at least got some kind of AST.
+    // Is there something we specifically need here? 
+  });
+});


### PR DESCRIPTION
* Trick `solc` into giving up all the dependencies. 
* Ask `solc` only for the AST when parsing completely.
* Add tests.