### PR TITLE
Typo in compileerror.js

### DIFF
--- a/compileerror.js
+++ b/compileerror.js
@@ -6,7 +6,7 @@ inherits(CompileError, TruffleError);
 
 function CompileError(message) {
   // Note we trim() because solc likes to add extra whitespace.
-  var fancy_message = message.trim() + "\n" + colors.red("Compiliation failed. See above.");
+  var fancy_message = message.trim() + "\n" + colors.red("Compilation failed. See above.");
   var normal_message = message.trim();
 
   CompileError.super_.call(this, normal_message);


### PR DESCRIPTION
Small typo in compilerror.js on "compilation" word.
Bit annoying to see it all day long 😃 