### PR TITLE
Use all contracts to determine dependent updates

### DIFF
--- a/profiler.js
+++ b/profiler.js
@@ -214,11 +214,11 @@ module.exports = {
 
         include(import_path);
 
-        if (ancestors.length > 0) {
+        if (ancestors && ancestors.length > 0) {
           ancestors.forEach(walk_from);
         }
 
-        if (dependencies.length > 0) {
+        if (dependencies && dependencies.length > 0) {
           dependencies.forEach(walk_down);
         }
       }

--- a/profiler.js
+++ b/profiler.js
@@ -231,6 +231,9 @@ module.exports = {
     find_contracts(options.base_path, function(err, allPaths) {
       if (err) return callback(err);
 
+      // Include paths for Solidity .sols, specified in options.
+      allPaths = allPaths.concat(paths);
+
       self.dependency_graph(allPaths, options.resolver, function(err, dependsGraph) {
         if (err) return callback(err);
 


### PR DESCRIPTION
Hopefully addressing some of the `invalid number of arguments to a Solidity function` problems.

Should fix tests in https://github.com/trufflesuite/truffle-core/pull/84

Refs: https://github.com/trufflesuite/truffle/issues/596 https://github.com/trufflesuite/truffle/issues/698 https://github.com/trufflesuite/truffle/issues/706 
(although these may or may not be the same issue)

(This replaces #40 to separate from the work in trufflesuite/truffle-artifactor#65)

- Fix issue where dependency graph was not complete - it only traced downstream from provided paths

- Instead, use all contracts via `truffle-contract-sources` to populate the dependency graph

Possibly warning: from what I can tell, this is going to make compilation even slower (cause now it effectively compiles a whole tree of contract dependencies)