### PR TITLE
Make functions appear in source-file order in all ABIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,10 @@ var compile = function(sources, options, callback) {
         }
       }
 
+      // Reorder ABI so functions are listed in the order they appear
+      // in the source file. Solidity tests need to execute in their expected sequence.
+      contract_definition.abi = orderABI(contract_definition);
+
       // Go through the link references and replace them with older-style
       // identifiers. We'll do this until we're ready to making a breaking
       // change to this code.
@@ -210,6 +214,63 @@ function replaceLinkReferences(bytecode, linkReferences, libraryName) {
 
   return bytecode;
 };
+
+function orderABI(contract){
+  var contract_definition;
+  var ordered_function_names = [];
+  var ordered_functions = [];
+
+  for (var i = 0; i < contract.ast.children.length; i++) {
+    var definition = contract.ast.children[i];
+
+    if (definition.name != "ContractDefinition") continue;
+
+    contract_definition = definition;
+    break;
+  }
+
+  if (!contract_definition) return contract.abi;
+  if (!contract_definition.children) return contract.abi;
+
+  contract_definition.children.forEach(function(child) {
+    if (child.name == "FunctionDefinition") {
+      ordered_function_names.push(child.attributes.name);
+    }
+  });
+
+  // Put function names in a hash with their order, lowest first, for speed.
+  var functions_to_remove = ordered_function_names.reduce(function(obj, value, index) {
+    obj[value] = index;
+    return obj;
+  }, {});
+
+  // Filter out functions from the abi
+  var function_definitions = contract.abi.filter(function(item) {
+    return functions_to_remove[item.name] != null;
+  });
+
+  // Sort removed function defintions
+  function_definitions = function_definitions.sort(function(item_a, item_b) {
+    var a = functions_to_remove[item_a.name];
+    var b = functions_to_remove[item_b.name];
+
+    if (a > b) return 1;
+    if (a < b) return -1;
+    return 0;
+  });
+
+  // Create a new ABI, placing ordered functions at the end.
+  var newABI = [];
+  contract.abi.forEach(function(item) {
+    if (functions_to_remove[item.name] != null) return;
+    newABI.push(item);
+  });
+
+  // Now pop the ordered functions definitions on to the end of the abi..
+  Array.prototype.push.apply(newABI, function_definitions);
+
+  return newABI;
+}
 
 
 // contracts_directory: String. Directory where .sol files can be found.

--- a/test/Ordered.sol
+++ b/test/Ordered.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.18;
+
+contract Ordered {
+  function theFirst() public pure {}
+  function second() public pure {}
+  function andThird() public pure {}
+}
+
+contract Empty {}

--- a/test/test_ordering.js
+++ b/test/test_ordering.js
@@ -1,0 +1,60 @@
+var fs = require("fs");
+var path = require("path");
+var solc = require("solc");
+var Compile = require("../index");
+var assert = require("assert");
+
+describe("Compile", function() {
+  this.timeout(5000); // solc
+  var orderedSource = null;
+  var emptySource = null;
+  var compileOptions = { contracts_directory: '', solc: ''};
+
+  describe("ABI Ordering", function(){
+    before("get code", function() {
+      orderedSource = fs.readFileSync(path.join(__dirname, "Ordered.sol"), "utf-8");
+    });
+
+    // Ordered.sol's methods are ordered semantically.
+    // solc alphabetizes methods within a file (but interpolates imported methods).
+    it("ABI should be out of source order when solc compiles it", function(){
+      var alphabetic = ['andThird', 'second', 'theFirst'];
+      var input = {
+        language: "Solidity",
+        sources: { "Ordered.sol": { content: orderedSource } },
+        settings: { outputSelection: { "*": { "*": ["abi"] } } }
+      };
+
+      var result = solc.compileStandard(JSON.stringify(input));
+      result = JSON.parse(result);
+      var abi = result.contracts["Ordered.sol"]["Ordered"].abi.map(function(item){
+        return item.name;
+      });
+      assert.deepEqual(abi, alphabetic);
+    });
+
+    it("orders the ABI", function(){
+      var expectedOrder = ['theFirst', 'second', 'andThird'];
+      var sources = {};
+      sources["Ordered.sol"] = orderedSource;
+
+      Compile(sources, compileOptions, function(err, result){
+        var abi = result["Ordered"].abi.map(function(item){
+          return item.name;
+        });
+        assert.deepEqual(abi, expectedOrder);
+      })
+    });
+
+    // Ported from `truffle-solidity-utils`
+    it("orders the ABI of a contract without functions", function(){
+      var sources = {};
+      sources["Ordered.sol"] = orderedSource;
+
+      Compile(sources, compileOptions, function(err, result){
+        assert.equal(result["Empty"].abi.length, 0);
+      })
+    })
+  })
+});
+


### PR DESCRIPTION
Rewrites contract ABIs so that functions are listed in the same order they appear in the source file and solidity tests execute in the sequence their author expects. 

PR just migrates [code](https://github.com/trufflesuite/truffle-solidity-utils/blob/develop/index.js#L8-L71) from `truffle-solidity-utils` and adapts its parsing for solc's ast. 

Part of removing vestigial dependence on`solidity-parser` to fix [truffle-695](https://github.com/trufflesuite/truffle/issues/695) / [truffle-707](https://github.com/trufflesuite/truffle/issues/707)