### PR TITLE
Allow newer versions of Solidity 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "colors": "^1.1.2",
     "debug": "^3.1.0",
     "graphlib": "^2.1.1",
-    "solc": "0.4.18",
+    "solc": "^0.4.18",
     "truffle-config": "^1.0.4",
     "truffle-contract-sources": "^0.0.1",
     "truffle-error": "^0.0.2",


### PR DESCRIPTION
Issue [#762](https://github.com/trufflesuite/truffle/issues/762): support solc 0.4.19.

Truffle should not restrict Solidity to version 0.4.18 because [semantic versioning](http://solidity.readthedocs.io/en/develop/layout-of-source-files.html#version-pragma) specifies that only non-breaking changes will be included in the 0.4.x series. Locking it to 0.4.18 means that users of Truffle cannot use Solidity 0.4.19 with its bug fixes, nor 0.4.20 when it comes along, etc.