### PR TITLE
Include new AST in contract output

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,8 +222,8 @@ function orderABI(contract){
   var ordered_function_names = [];
   var ordered_functions = [];
 
-  for (var i = 0; i < contract.ast.children.length; i++) {
-    var definition = contract.ast.children[i];
+  for (var i = 0; i < contract.legacyAST.children.length; i++) {
+    var definition = contract.legacyAST.children[i];
 
     if (definition.name != "ContractDefinition") continue;
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,8 @@ var compile = function(sources, options, callback) {
       outputSelection: {
         "*": {
           "": [
-            "legacyAST"
+            "legacyAST",
+            "ast"
           ],
           "*": [
             "abi",
@@ -150,7 +151,8 @@ var compile = function(sources, options, callback) {
         source: operatingSystemIndependentSources[source_path],
         sourceMap: contract.evm.bytecode.sourceMap,
         deployedSourceMap: contract.evm.deployedBytecode.sourceMap,
-        ast: standardOutput.sources[source_path].legacyAST,
+        legacyAST: standardOutput.sources[source_path].legacyAST,
+        ast: standardOutput.sources[source_path].ast,
         abi: contract.abi,
         bytecode: "0x" + contract.evm.bytecode.object,
         deployedBytecode: "0x" + contract.evm.deployedBytecode.object,


### PR DESCRIPTION
- Use `ast` for new AST, using `legacyAST` for legacyAST
- Update ABI ordering logic to use `legacyAST`