### PR TITLE
Order ABI correctly in multi-contract files

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,12 @@ function orderABI(contract){
   for (var i = 0; i < contract.legacyAST.children.length; i++) {
     var definition = contract.legacyAST.children[i];
 
-    if (definition.name != "ContractDefinition") continue;
+    // AST can have multiple contract definitions, make sure we have the
+    // one that matches our contract
+    if (definition.name !== "ContractDefinition" ||
+        definition.attributes.name !== contract.contract_name){
+      continue;
+    }
 
     contract_definition = definition;
     break;

--- a/test/ComplexOrdered.sol
+++ b/test/ComplexOrdered.sol
@@ -10,7 +10,7 @@ contract InheritA is InheritB {
   function InheritA() public {}
 }
 
-contract Ordered is InheritA {
+contract ComplexOrdered is InheritA {
   function theFirst() public pure {}
   function second() public pure {}
   function andThird() public pure {}

--- a/test/InheritB.sol
+++ b/test/InheritB.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.18;
+
+// These are out of alphabetic order
+// Solc will alphabetize them, we should restore source-order.
+contract InheritB {
+  event LogD();
+  event LogC();
+  function InheritB() public {}
+}

--- a/test/Ordered.sol
+++ b/test/Ordered.sol
@@ -1,6 +1,16 @@
 pragma solidity ^0.4.18;
 
-contract Ordered {
+import "./InheritB.sol";
+
+// These are out of alphabetic order
+// Solc will alphabetize them, we should restore source-order.
+contract InheritA is InheritB {
+  event LogB();
+  event LogA();
+  function InheritA() public {}
+}
+
+contract Ordered is InheritA {
   function theFirst() public pure {}
   function second() public pure {}
   function andThird() public pure {}

--- a/test/SimpleOrdered.sol
+++ b/test/SimpleOrdered.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.18;
+
+// These are out of alphabetic order
+// Solc will alphabetize them, we should restore source-order.
+contract SimpleOrdered {
+  function theFirst() public pure {}
+  function second() public pure {}
+  function andThird() public pure {}
+}

--- a/test/test_ordering.js
+++ b/test/test_ordering.js
@@ -13,15 +13,17 @@ describe("Compile", function() {
   describe("ABI Ordering", function(){
     before("get code", function() {
       orderedSource = fs.readFileSync(path.join(__dirname, "Ordered.sol"), "utf-8");
+      inheritedSource = fs.readFileSync(path.join(__dirname, "InheritB.sol"), "utf-8");
     });
 
     // Ordered.sol's methods are ordered semantically.
     // solc alphabetizes methods within a file (but interpolates imported methods).
     it("ABI should be out of source order when solc compiles it", function(){
-      var alphabetic = ['andThird', 'second', 'theFirst'];
+      var alphabetic = ['andThird', 'second', 'theFirst', 'LogB', 'LogA', 'LogD', 'LogC'];
       var input = {
         language: "Solidity",
-        sources: { "Ordered.sol": { content: orderedSource } },
+        sources: { "Ordered.sol": { content: orderedSource },
+                   "InheritB.sol": { content: inheritedSource },},
         settings: { outputSelection: { "*": { "*": ["abi"] } } }
       };
 
@@ -34,9 +36,10 @@ describe("Compile", function() {
     });
 
     it("orders the ABI", function(){
-      var expectedOrder = ['theFirst', 'second', 'andThird'];
+      var expectedOrder = ['theFirst', 'second', 'andThird', 'LogB', 'LogA', 'LogD', 'LogC'];
       var sources = {};
       sources["Ordered.sol"] = orderedSource;
+      sources["InheritB.sol"] = inheritedSource;
 
       Compile(sources, compileOptions, function(err, result){
         var abi = result["Ordered"].abi.map(function(item){
@@ -50,6 +53,7 @@ describe("Compile", function() {
     it("orders the ABI of a contract without functions", function(){
       var sources = {};
       sources["Ordered.sol"] = orderedSource;
+      sources["InheritB.sol"] = inheritedSource;
 
       Compile(sources, compileOptions, function(err, result){
         assert.equal(result["Empty"].abi.length, 0);


### PR DESCRIPTION
Addresses [truffle 812](https://github.com/trufflesuite/truffle/issues/812)

While processing the AST to identify `ContractDefinitions`, we have to make sure a given definition node matches the contract name. Solc produces an AST that lays out all the contracts in a file adjacently but only one of these belongs to the contract in question. 

Re-factored the tests so that we have examples of single contract files, multi-contract files and inheritance from an imported file. 