### PR TITLE
Skip warnings and fix imports in truffle publish

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,6 +1,7 @@
 var CompileError = require("./compileerror");
 var solc = require("solc");
 var fs = require("fs");
+var path = require("path");
 
 // Clean up after solc.
 var listeners = process.listeners("uncaughtException");
@@ -13,13 +14,32 @@ if (solc_listener) {
 // Warning issued by a pre-release compiler version, ignored by this component.
 var preReleaseCompilerWarning = "This is a pre-release compiler version, please do not use it in production.";
 
+var installedContractsDir = "installed_contracts"
+
 module.exports = {
   parse: function(body, fileName) {
     // Here, we want a valid AST even if imports don't exist. The way to
     // get around that is to tell the compiler, as they happen, that we
     // have source for them (an empty file).
 
+    var build_remappings = function() {
+      // Maps import paths to paths from EthPM installed contracts, so we can correctly solve imports
+      // e.g. "my_pkg/=installed_contracts/my_pkg/contracts/"
+      var remappings = [];
+
+      if (fs.existsSync('ethpm.json')) {
+        ethpm = JSON.parse(fs.readFileSync('ethpm.json'));
+        for (pkg in ethpm.dependencies) {
+          remappings.push(pkg + "/=" + path.join(installedContractsDir, pkg, 'contracts', '/'));
+        }
+      }
+      
+      return remappings;
+    }
+
     var fileName = fileName || "ParsedContract.sol";
+
+    var remappings = build_remappings();
 
     var solcStandardInput = {
       language: "Solidity",
@@ -29,6 +49,7 @@ module.exports = {
         }
       },
       settings: {
+        remappings: remappings,
         outputSelection: {
           "*": {
             "": [
@@ -40,13 +61,14 @@ module.exports = {
     };
 
     var output = solc.compileStandard(JSON.stringify(solcStandardInput), function(file_path) {
-      // Tell the compiler we have source code for the dependency
-      path_components = file_path.split(/\/(.+)/);
-      package_name = path_components[0];
-      sol_path = path_components[1];
-
-      dep_path = 'installed_contracts/'+package_name+'/contracts/'+sol_path;
-      return {contents: fs.readFileSync(dep_path, {encoding: 'UTF-8'})};
+      // Resolve dependency manually.
+      if (fs.existsSync(file_path)) {
+        contents = fs.readFileSync(file_path, {encoding: 'UTF-8'});
+      }
+      else {
+        contents = "pragma solidity ^0.4.0;";
+      }
+      return {contents: contents};
     });
 
     output = JSON.parse(output);
@@ -57,12 +79,12 @@ module.exports = {
     }) : [];
 
     // Filter out warnings.
-    var warnings = output.errors.filter(function(solidity_error) {
+    var warnings = output.errors ? output.errors.filter(function(solidity_error) {
       return solidity_error.severity == "warning";
-    });
-    var errors = output.errors.filter(function(solidity_error) {
+    }) : [];
+    var errors = output.errors ? output.errors.filter(function(solidity_error) {
       return solidity_error.severity != "warning";
-    });
+    }) : [];
 
     if (errors.length > 0) {
       throw new CompileError(errors[0].formattedMessage);

--- a/parser.js
+++ b/parser.js
@@ -1,5 +1,6 @@
 var CompileError = require("./compileerror");
 var solc = require("solc");
+var fs = require("fs");
 
 // Clean up after solc.
 var listeners = process.listeners("uncaughtException");
@@ -40,7 +41,12 @@ module.exports = {
 
     var output = solc.compileStandard(JSON.stringify(solcStandardInput), function(file_path) {
       // Tell the compiler we have source code for the dependency
-      return {contents: "pragma solidity ^0.4.0;"};
+      path_components = file_path.split(/\/(.+)/);
+      package_name = path_components[0];
+      sol_path = path_components[1];
+
+      dep_path = 'installed_contracts/'+package_name+'/contracts/'+sol_path;
+      return {contents: fs.readFileSync(dep_path, {encoding: 'UTF-8'})};
     });
 
     output = JSON.parse(output);

--- a/parser.js
+++ b/parser.js
@@ -50,6 +50,14 @@ module.exports = {
       return solidity_error.message.indexOf(preReleaseCompilerWarning) < 0;
     }) : [];
 
+    // Filter out warnings.
+    var warnings = output.errors.filter(function(solidity_error) {
+      return solidity_error.severity == "warning";
+    });
+    var errors = output.errors.filter(function(solidity_error) {
+      return solidity_error.severity != "warning";
+    });
+
     if (errors.length > 0) {
       throw new CompileError(errors[0].formattedMessage);
     }


### PR DESCRIPTION
This does 2 changes to fix publish errors in certain cases.

1. It skips the compiler warnings causing `truffle publish` to fail.
2. It implements import path resolution for `installed_contracts`. This part is a bit hard-coded. I'll improve it, but I wanted to submit this, so we can discuss the solution.

See https://github.com/trufflesuite/truffle/issues/744