### PR TITLE
Bump solc to 0.4.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "colors": "^1.1.2",
     "debug": "^3.1.0",
     "graphlib": "^2.1.1",
-    "solc": "^0.4.19",
+    "solc": "^0.4.21",
     "truffle-config": "^1.0.4",
     "truffle-contract-sources": "^0.0.1",
     "truffle-error": "^0.0.2",


### PR DESCRIPTION
Upgrades solc to `0.4.21`. 

Release notes [link](https://github.com/ethereum/solidity/releases/tag/v0.4.21)
Addresses #50.