### PR TITLE
Provide callback with file indexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,12 @@ var compile = function(sources, options, callback) {
 
   var contracts = standardOutput.contracts;
 
+  var files = [];
+  Object.keys(standardOutput.sources).forEach(function(filename) {
+    var source = standardOutput.sources[filename];
+    files[source.id] = filename;
+  });
+
   var returnVal = {};
 
   // This block has comments in it as it's being prepared for solc > 0.4.10
@@ -196,8 +202,7 @@ var compile = function(sources, options, callback) {
     });
   });
 
-  // TODO: Is the third parameter needed?
-  callback(null, returnVal, Object.keys(sources));
+  callback(null, returnVal, files);
 };
 
 function replaceLinkReferences(bytecode, linkReferences, libraryName) {


### PR DESCRIPTION
Since compiler output AST and sourcemaps reference specific files by index.

(Addressing TODO: this third arg was not found in use anywhere)