### PR TITLE
Minimize compilation set

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ var compile = function(sources, options, callback) {
     options.logger = console;
   }
 
+  var hasTargets = options.compilationTargets && options.compilationTargets.length;
+
   expect.options(options, [
     "contracts_directory",
     "solc"
@@ -67,7 +69,7 @@ var compile = function(sources, options, callback) {
 
     // Just substitute replacement for original in target case. It's
     // a disposable subset of `sources`
-    if(options.compilationTargets && options.compilationTargets[source]){
+    if(hasTargets && options.compilationTargets.includes(source)){
       operatingSystemIndependentTargets[replacement] = sources[source];
     }
 

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ var compile = function(sources, options, callback) {
   }
 
   // Specify compilation targets
+  // Each target uses defaultSelectors, defaulting to single target `*` if targets are unspecified
   var outputSelection = {};
   var targets = operatingSystemIndependentTargets;
   var targetPaths = Object.keys(targets);

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ compile.with_dependencies = function(options, callback) {
   }), (err, allSources, required) => {
     if (err) return callback(err);
 
-    var hasTargets = Object.keys(required).length;
+    var hasTargets = required.length;
 
     (hasTargets)
       ? self.display(required, options)
@@ -377,15 +377,15 @@ compile.with_dependencies = function(options, callback) {
 
 compile.display = function(paths, options){
   if (options.quiet != true) {
-    Object
-      .keys(paths)
-      .sort()
-      .forEach(contract => {
+    if (!Array.isArray(paths)){
+      paths = Object.keys(paths);
+    }
 
-        if (path.isAbsolute(contract)) {
-          contract = "." + path.sep + path.relative(options.working_directory, contract);
-        }
-        options.logger.log("Compiling " + contract + "...");
+    paths.sort().forEach(contract => {
+      if (path.isAbsolute(contract)) {
+        contract = "." + path.sep + path.relative(options.working_directory, contract);
+      }
+      options.logger.log("Compiling " + contract + "...");
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -46,10 +46,10 @@ var compile = function(sources, options, callback) {
     process.removeListener("uncaughtException", solc_listener);
   }
 
-
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
   var operatingSystemIndependentSources = {};
+  var operatingSystemIndependentTargets = {};
   var originalPathMappings = {};
 
   Object.keys(sources).forEach(function(source) {
@@ -65,30 +65,45 @@ var compile = function(sources, options, callback) {
     // Save the result
     operatingSystemIndependentSources[replacement] = sources[source];
 
+    // Just substitute replacement for original in target case. It's
+    // a disposable subset of `sources`
+    if(options.compilationTargets && options.compilationTargets[source]){
+      operatingSystemIndependentTargets[replacement] = sources[source];
+    }
+
     // Map the replacement back to the original source path.
     originalPathMappings[replacement] = source;
   });
+
+  var defaultSelectors = {
+   "": [
+      "legacyAST",
+      "ast"
+    ],
+    "*": [
+      "abi",
+      "evm.bytecode.object",
+      "evm.bytecode.sourceMap",
+      "evm.deployedBytecode.object",
+      "evm.deployedBytecode.sourceMap"
+    ]
+  }
+
+  // Specify compilation targets
+  var outputSelection = {};
+  var targets = operatingSystemIndependentTargets;
+  var targetPaths = Object.keys(targets);
+
+  (targetPaths.length)
+    ? targetPaths.forEach(key => outputSelection[key] = defaultSelectors)
+    : outputSelection["*"] = defaultSelectors;
 
   var solcStandardInput = {
     language: "Solidity",
     sources: {},
     settings: {
       optimizer: options.solc.optimizer,
-      outputSelection: {
-        "*": {
-          "": [
-            "legacyAST",
-            "ast"
-          ],
-          "*": [
-            "abi",
-            "evm.bytecode.object",
-            "evm.bytecode.sourceMap",
-            "evm.deployedBytecode.object",
-            "evm.deployedBytecode.sourceMap"
-          ]
-        },
-      }
+      outputSelection: outputSelection,
     }
   };
 
@@ -150,6 +165,10 @@ var compile = function(sources, options, callback) {
 
     Object.keys(files_contracts).forEach(function(contract_name) {
       var contract = files_contracts[contract_name];
+
+      // All source will have a key, but only the compiled source will have
+      // the evm output.
+      if (!Object.keys(contract.evm).length) return;
 
       var contract_definition = {
         contract_name: contract_name,
@@ -289,8 +308,10 @@ function orderABI(contract){
 // quiet: Boolean. Suppress output. Defaults to false.
 // strict: Boolean. Return compiler warnings as errors. Defaults to false.
 compile.all = function(options, callback) {
-  var self = this;
+
   find_contracts(options.contracts_directory, function(err, files) {
+    if (err) return callback(err)
+
     options.paths = files;
     compile.with_dependencies(options, callback);
   });
@@ -319,6 +340,8 @@ compile.necessary = function(options, callback) {
 };
 
 compile.with_dependencies = function(options, callback) {
+  var self = this;
+
   options.logger = options.logger || console;
   options.contracts_directory = options.contracts_directory || process.cwd();
 
@@ -331,26 +354,37 @@ compile.with_dependencies = function(options, callback) {
 
   var config = Config.default().merge(options);
 
-  var self = this;
   Profiler.required_sources(config.with({
     paths: options.paths,
     base_path: options.contracts_directory,
     resolver: options.resolver
-  }), function(err, result) {
+  }), (err, allSources, required) => {
     if (err) return callback(err);
 
-    if (options.quiet != true) {
-      Object.keys(result).sort().forEach(function(import_path) {
-        var display_path = import_path;
-        if (path.isAbsolute(import_path)) {
-          display_path = "." + path.sep + path.relative(options.working_directory, import_path);
-        }
-        options.logger.log("Compiling " + display_path + "...");
-      });
-    }
+    var hasTargets = Object.keys(required).length;
 
-    compile(result, options, callback);
+    (hasTargets)
+      ? self.display(required, options)
+      : self.display(allSources, options);
+
+    options.compilationTargets = required;
+    compile(allSources, options, callback);
   });
 };
+
+compile.display = function(paths, options){
+  if (options.quiet != true) {
+    Object
+      .keys(paths)
+      .sort()
+      .forEach(contract => {
+
+        if (path.isAbsolute(contract)) {
+          contract = "." + path.sep + path.relative(options.working_directory, contract);
+        }
+        options.logger.log("Compiling " + contract + "...");
+    });
+  }
+}
 
 module.exports = compile;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "async": "^2.1.4",
     "colors": "^1.1.2",
     "debug": "^3.1.0",
-    "graphlib": "^2.1.1",
     "solc": "^0.4.21",
     "truffle-config": "^1.0.4",
     "truffle-contract-sources": "^0.0.1",

--- a/profiler.js
+++ b/profiler.js
@@ -205,7 +205,10 @@ module.exports = {
         // Seed compilationTargets with known updates
         updates.forEach(update => compilationTargets.push(update));
 
-        // While updates: dequeue
+        // While there are updated files in the queue, we take each one
+        // and search the entire file corpus to find any sources that import it.
+        // Those sources are added to list of compilation targets as well as
+        // the update queue because their own ancestors need to be discovered.
         async.whilst(() => updates.length > 0, updateFinished => {
           var currentUpdate = updates.shift();
           var files = allPaths.slice();

--- a/profiler.js
+++ b/profiler.js
@@ -185,7 +185,7 @@ module.exports = {
       var allPaths = self.convert_to_absolute_paths(allPaths, options.base_path).sort();
 
       var allSources = {};
-      var compilationTargets = {};
+      var compilationTargets = [];
 
       // Get all the source code
       self.resolveAllSources(resolver, allPaths, (err, resolved) => {
@@ -203,7 +203,7 @@ module.exports = {
         }
 
         // Seed compilationTargets with known updates
-        updates.forEach(update => compilationTargets[update] = resolved[update].body);
+        updates.forEach(update => compilationTargets.push(update));
 
         // While updates: dequeue
         async.whilst(() => updates.length > 0, updateFinished => {
@@ -216,7 +216,7 @@ module.exports = {
             var currentFile = files.shift();
 
             // Ignore targets already selected.
-            if (compilationTargets[currentFile]){
+            if (compilationTargets.includes(currentFile)){
               return fileFinished();
             }
 
@@ -232,7 +232,7 @@ module.exports = {
             // to list of updates and compilation targets
             if (imports.includes(currentUpdate)){
               updates.push(currentFile);
-              compilationTargets[currentFile] = resolved[currentFile].body;
+              compilationTargets.push(currentFile);
             }
 
             fileFinished();


### PR DESCRIPTION
Implements #23 and restores intended profiler behavior. All sources are passed to solc input, but updated contracts and their 'ancestors' (e.g the contracts that inherit them) are specified as compilation targets in solc's output object.

This entailed a bit of a rewrite of the comp logic, which is both intricate and critical to truffle's normal functioning :).  Warning emoji. 

There is a PR with [new unit tests](https://github.com/trufflesuite/truffle/pull/883) for this at `truffle`. And another [PR](https://github.com/trufflesuite/truffle-core) at `truffle-core` with changes to its tests to accommodate new behavior. 