### PR TITLE
Fix `compile()` to callback original path mappings

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ var compile = function(sources, options, callback) {
   var files = [];
   Object.keys(standardOutput.sources).forEach(function(filename) {
     var source = standardOutput.sources[filename];
-    files[source.id] = filename;
+    files[source.id] = originalPathMappings[filename];
   });
 
   var returnVal = {};


### PR DESCRIPTION
Ref: trufflesuite/truffle#885

Because `solc` outputs os-independent paths like `/c/Users/gnidan/.../ConvertLib.sol`, we need to convert these back to whatever path was originally specified instead.