### PR TITLE
Allow compile with native built solc & dockerized solc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: trusty
 sudo: required
-
-language: generic
+language: node_js
+node_js:
+  - "6"
 
 services:
   - docker
@@ -9,18 +11,10 @@ before_install:
   - docker pull truffle/ci
 
 env:
+  - TEST=native
   - TEST=repo
   - TEST=upstream
   - TEST=scenario
 
 script:
-  - >
-    docker run -it --rm --name ${TEST} \
-        -e TRAVIS_REPO_SLUG \
-        -e TRAVIS_PULL_REQUEST \
-        -e TRAVIS_PULL_REQUEST_SLUG \
-        -e TRAVIS_PULL_REQUEST_BRANCH \
-        -e TRAVIS_BRANCH \
-        -e TEST \
-        -e CI \
-      truffle/ci:latest run_tests
+  - npm run test:ci

--- a/compilerProvider.js
+++ b/compilerProvider.js
@@ -47,6 +47,7 @@ CompilerProvider.prototype.cachePath = findCacheDir({
  *
  * OR specify that solc.compileStandard should wrap:
  * - dockerized solc               (config.solc = "<image-name>" && config.docker: true)
+ * - native built solc             (cofing.solc = "native")
  *
  * @return {Module|Object}         solc
  */
@@ -375,12 +376,19 @@ CompilerProvider.prototype.errors = function(kind, input, err){
   const info = 'Run `truffle compile --list` to see available versions.'
 
   const kinds = {
+
     noPath:    "Could not find compiler at: " + input,
     noVersion: "Could not find compiler version:\n" + input + ".\n" + info,
-    noString:  "`compiler.solc` option must be string specifying a path, solc version, or docker image, got: " + input,
     noRequest: "Failed to complete request to: " + input + ".\n\n" + err,
-    noDocker: "You are trying to run dockerized solc, but docker is not installed on this machine.",
-    noImage: "Please pull " + input + " from docker before trying to compile with it.",
+    noDocker:  "You are trying to run dockerized solc, but docker is not installed.",
+    noImage:   "Please pull " + input + " from docker before trying to compile with it.",
+
+    // Lists
+    noString:  "`compiler.solc` option must be a string specifying:\n" +
+               "   - a path to a locally installed solcjs\n" +
+               "   - a solc version (ex: '0.4.22')\n" +
+               "   - a docker image name (ex: 'stable')\n" +
+               "Received: " + input + " instead.",
   }
 
   return new Error(kinds[kind]);

--- a/compilerProvider.js
+++ b/compilerProvider.js
@@ -289,7 +289,6 @@ CompilerProvider.prototype.isCached = function(fileName){
   return fs.existsSync(file);
 }
 
-
 /**
  * Write  to the cache at `config.cachePath`. Creates `cachePath` directory if
  * does not exist.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     ]
   },
   "scripts": {
-    "test": "mocha --timeout 5000 --compilers js:babel-core/register --require babel-polyfill test"
+    "test": "mocha --invert --grep native --timeout 5000 --compilers js:babel-core/register --require babel-polyfill test",
+    "test:native": "mocha --grep native --timeout 5000 --compilers js:babel-core/register --require babel-polyfill test",
+    "test:ci": "./scripts/ci.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "mocha": "^3.5.3",
-    "tmp": "0.0.33",
     "truffle-resolver": "2.0.0"
   },
   "babel": {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -3,6 +3,10 @@
 set -o errexit
 
 run_native_tests() {
+  sudo add-apt-repository --yes ppa:ethereum/ethereum
+  sudo apt-get update
+  sudo apt-get install solc
+
   docker pull ethereum/solc:0.4.22
   npm install
   npm run test:native
@@ -20,7 +24,7 @@ run_container_tests() {
 }
 
 if [ "$TEST" == "native" ]; then
-  run_solc_native_tests
+  run_native_tests
 else
   run_container_tests
 fi

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+run_native_tests() {
+  docker pull ethereum/solc:0.4.22
+  npm install
+  npm run test:native
+}
+
+run_container_tests() {
+  docker run -it --rm --name ${TEST} \
+    -e TRAVIS_REPO_SLUG \
+    -e TRAVIS_PULL_REQUEST \
+    -e TRAVIS_PULL_REQUEST_SLUG \
+    -e TRAVIS_PULL_REQUEST_BRANCH \
+    -e TRAVIS_BRANCH \
+    -e TEST \
+  truffle/ci:latest run_tests
+}
+
+if [ "$TEST" == "native" ]; then
+  run_solc_native_tests
+else
+  run_container_tests
+fi

--- a/test/test_provider.js
+++ b/test/test_provider.js
@@ -214,6 +214,8 @@ describe('CompilerProvider', function(){
         };
 
         compile(newPragmaSource, options, (err, result) => {
+          if (err) return done(err);
+
           assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
           done();
         });
@@ -226,6 +228,8 @@ describe('CompilerProvider', function(){
         };
 
         compile(newPragmaSource, options, (err, result) => {
+          if (err) return done(err);
+
           assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
           done();
         });

--- a/test/test_provider.js
+++ b/test/test_provider.js
@@ -206,7 +206,18 @@ describe('CompilerProvider', function(){
       });
     });
 
-    describe('docker [ @native ]', function() {
+    describe('native / docker [ @native ]', function() {
+
+      it('compiles with native solc', function(done){
+        options.compiler = {
+          solc: "native"
+        };
+
+        compile(newPragmaSource, options, (err, result) => {
+          assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
+          done();
+        });
+      });
 
       it('compiles with dockerized solc', function(done){
         options.compiler = {
@@ -233,7 +244,7 @@ describe('CompilerProvider', function(){
       })
 
       it('errors if running dockerized solc when image does not exist locally', function(done){
-        const imageName = 'fantasySolc.777555';
+        const imageName = 'fantasySolc.7777555';
 
         options.compiler = {
           solc: imageName,

--- a/test/test_provider.js
+++ b/test/test_provider.js
@@ -196,53 +196,55 @@ describe('CompilerProvider', function(){
             assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
 
             // atime is not getting updated on read in CI.
-            if (!process.env.CI){
+            if (!process.env.TEST){
               assert(initialAccessTime < finalAccessTime, "Should have used cached compiler");
             }
 
             done();
           });
-
         }).catch(done);
       });
     });
 
-    it('compiles with dockerized solc', function(done){
-      options.compiler = {
-        solc: "0.4.22",
-        docker: true
-      };
+    describe('docker [ @native ]', function() {
 
-      compile(newPragmaSource, options, (err, result) => {
-        assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
-        done();
+      it('compiles with dockerized solc', function(done){
+        options.compiler = {
+          solc: "0.4.22",
+          docker: true
+        };
+
+        compile(newPragmaSource, options, (err, result) => {
+          assert(result['NewPragma'].contract_name === 'NewPragma', 'Should have compiled');
+          done();
+        });
       });
+
+      it('errors if running dockerized solc without specifying an image', function(done){
+        options.compiler = {
+          solc: undefined,
+          docker: true
+        };
+
+        compile(newPragmaSource, options, (err, result) => {
+          assert(err.message.includes('option must be'));
+          done();
+        });
+      })
+
+      it('errors if running dockerized solc when image does not exist locally', function(done){
+        const imageName = 'fantasySolc.777555';
+
+        options.compiler = {
+          solc: imageName,
+          docker: true
+        };
+
+        compile(newPragmaSource, options, (err, result) => {
+          assert(err.message.includes(imageName));
+          done();
+        });
+      })
     });
-
-    it('errors if running dockerized solc without specifying an image', function(done){
-      options.compiler = {
-        solc: undefined,
-        docker: true
-      };
-
-      compile(newPragmaSource, options, (err, result) => {
-        assert(err.message.includes('option must be'));
-        done();
-      });
-    })
-
-    it('errors if running dockerized solc when image does not exist locally', function(done){
-      const imageName = 'fantasySolc.777555';
-
-      options.compiler = {
-        solc: imageName,
-        docker: true
-      };
-
-      compile(newPragmaSource, options, (err, result) => {
-        assert(err.message.includes(imageName));
-        done();
-      });
-    })
   });
 });


### PR DESCRIPTION
+ Adds ability to configure truffle to use natively installed solc and dockerized solc. 
+ Adds tests for these compiler variants in CI

**Config API**
```javascript
// Native
compiler: {
  solc: "native"
}
// Docker 
compiler: {
  solc: "0.4.22",   // Any published image name
  docker: true
}
```

Solc docker images are listed [here](https://hub.docker.com/r/ethereum/solc/tags/) and can be installed locally by running:
```
docker pull ethereum/solc:0.4.22  // Example image
```

Instructions for installing solc binaries vary by OS and are detailed in the Solidity docs [here](https://solidity.readthedocs.io/en/v0.4.22/installing-solidity.html). CI uses the linux distribution which also seems like the simplest. 