### PR TITLE
Optimize `require` and `docker` calls (BYOC)

### DIFF
--- a/compilerProvider.js
+++ b/compilerProvider.js
@@ -5,6 +5,7 @@ const request = require('request-promise');
 const requireFromString = require('require-from-string');
 const findCacheDir = require('find-cache-dir');
 const originalRequire = require('original-require');
+const solcWrap = require('./solcWrap.js');
 
 
 //------------------------------ Constructor/Config ------------------------------------------------
@@ -379,9 +380,11 @@ CompilerProvider.prototype.addToCache = function(code, fileName){
  * @return {Module}       solc
  */
 CompilerProvider.prototype.getFromCache = function(fileName){
-  const filePath = this.resolveCache(fileName)
-  const cached = fs.readFileSync(filePath, "utf-8");
-  return this.compilerFromString(cached);
+  const filePath = this.resolveCache(fileName);
+  const soljson = require(filePath);
+  const wrapped = solcWrap(soljson);
+  this.removeListener();
+  return wrapped;
 }
 
 /**
@@ -390,9 +393,8 @@ CompilerProvider.prototype.getFromCache = function(fileName){
  * @return {Module}      solc
  */
 CompilerProvider.prototype.compilerFromString = function(code){
-  const solc = this.getDefault();
-  const compiler = requireFromString(code);
-  const wrapped = solc.setupMethods(compiler);
+  const soljson = requireFromString(code);
+  const wrapped = solcWrap(soljson);
   this.removeListener();
   return wrapped;
 }

--- a/compilerProvider.js
+++ b/compilerProvider.js
@@ -125,7 +125,7 @@ CompilerProvider.prototype.getDockerTags = function(){
 //------------------------------------ Getters -----------------------------------------------------
 
 /**
- * Gets solc from local `node_modules`. Equivalent to `require("solc")`
+ * Gets solc from `node_modules`.`
  * @return {Module} solc
  */
 CompilerProvider.prototype.getDefault = function(){
@@ -135,7 +135,7 @@ CompilerProvider.prototype.getDefault = function(){
 }
 
 /**
- * Gets an npm installed solc from specified absolute path.
+ * Gets an npm installed solc from specified path.
  * @param  {String} localPath
  * @return {Module}
  */
@@ -391,7 +391,7 @@ CompilerProvider.prototype.addToCache = function(code, fileName){
  */
 CompilerProvider.prototype.getFromCache = function(fileName){
   const filePath = this.resolveCache(fileName);
-  const soljson = require(filePath);
+  const soljson = originalRequire(filePath);
   const wrapped = solcWrap(soljson);
   this.removeListener();
   return wrapped;

--- a/solcWrap.js
+++ b/solcWrap.js
@@ -1,0 +1,78 @@
+/**
+ * This is a truncated version of soljs's wrapper for soljson.js (the solc js file available
+ * at solc-bin. Using this allows us to avoid requiring solc twice, cutting ~2s off the load time)
+ */
+
+var assert = require('assert');
+
+function solcWrap (soljson) {
+  var compileJSON = soljson.cwrap('compileJSON', 'string', ['string', 'number']);
+  var compileJSONMulti = null;
+  if ('_compileJSONMulti' in soljson) {
+    compileJSONMulti = soljson.cwrap('compileJSONMulti', 'string', ['string', 'number']);
+  }
+  var compileJSONCallback = null;
+  var compileStandard = null;
+  if (('_compileJSONCallback' in soljson) || ('_compileStandard' in soljson)) {
+    var copyString = function (str, ptr) {
+      var length = soljson.lengthBytesUTF8(str);
+      var buffer = soljson._malloc(length + 1);
+      soljson.stringToUTF8(str, buffer, length + 1);
+      soljson.setValue(ptr, buffer, '*');
+    };
+    var wrapCallback = function (callback) {
+      assert(typeof callback === 'function', 'Invalid callback specified.');
+      return function (path, contents, error) {
+        var result = callback(soljson.Pointer_stringify(path));
+        if (typeof result.contents === 'string') {
+          copyString(result.contents, contents);
+        }
+        if (typeof result.error === 'string') {
+          copyString(result.error, error);
+        }
+      };
+    };
+
+    // This calls compile() with args || cb
+    var runWithReadCallback = function (readCallback, compile, args) {
+      if (readCallback === undefined) {
+        readCallback = function (path) {
+          return {
+            error: 'File import callback not supported'
+          };
+        };
+      }
+      var cb = soljson.Runtime.addFunction(wrapCallback(readCallback));
+      var output;
+      try {
+        args.push(cb);
+        output = compile.apply(undefined, args);
+      } catch (e) {
+        soljson.Runtime.removeFunction(cb);
+        throw e;
+      }
+      soljson.Runtime.removeFunction(cb);
+      return output;
+    };
+
+    var compileInternal = soljson.cwrap('compileJSONCallback', 'string', ['string', 'number', 'number']);
+    compileJSONCallback = function (input, optimize, readCallback) {
+      return runWithReadCallback(readCallback, compileInternal, [ input, optimize ]);
+    };
+    if ('_compileStandard' in soljson) {
+      var compileStandardInternal = soljson.cwrap('compileStandard', 'string', ['string', 'number']);
+      compileStandard = function (input, readCallback) {
+        return runWithReadCallback(readCallback, compileStandardInternal, [ input ]);
+      };
+    }
+  }
+
+  var version = soljson.cwrap('version', 'string', []);
+
+  return {
+    compileStandard: compileStandard,
+    version: version,
+  };
+}
+
+module.exports = solcWrap;

--- a/solcWrap.js
+++ b/solcWrap.js
@@ -55,12 +55,24 @@ function solcWrap (soljson) {
       return output;
     };
 
-    var compileInternal = soljson.cwrap('compileJSONCallback', 'string', ['string', 'number', 'number']);
+    var compileInternal = soljson.cwrap(
+      'compileJSONCallback',
+      'string',
+      ['string', 'number', 'number']
+    );
+
     compileJSONCallback = function (input, optimize, readCallback) {
       return runWithReadCallback(readCallback, compileInternal, [ input, optimize ]);
     };
+
     if ('_compileStandard' in soljson) {
-      var compileStandardInternal = soljson.cwrap('compileStandard', 'string', ['string', 'number']);
+
+      var compileStandardInternal = soljson.cwrap(
+        'compileStandard',
+        'string',
+        ['string', 'number']
+      );
+
       compileStandard = function (input, readCallback) {
         return runWithReadCallback(readCallback, compileStandardInternal, [ input ]);
       };

--- a/test/test_provider.js
+++ b/test/test_provider.js
@@ -9,7 +9,7 @@ const CompilerProvider = require('../compilerProvider');
 
 
 function waitSecond() {
-  return new Promise((resolve, reject) => setTimeout(() => resolve(), 5000));
+  return new Promise((resolve, reject) => setTimeout(() => resolve(), 1250));
 }
 
 describe('CompilerProvider', function(){
@@ -178,6 +178,9 @@ describe('CompilerProvider', function(){
 
       const thunk = findCacheDir({name: 'truffle', thunk: true});
       const expectedCache = thunk('soljson-v0.4.21+commit.dfe3193c.js');
+
+      // Delete if it's already there.
+      if (fs.existsSync(expectedCache)) fs.unlinkSync(expectedCache);
 
       options.compiler = {
         cache: true,


### PR DESCRIPTION
These changes cut at least 3 seconds of run-time overhead (for compiler runs after an initial set-up run that caches resources).  [Comment](https://github.com/trufflesuite/truffle-compile/issues/66#issuecomment-385040328) in #66 has more details.

+ Added some light solc wrapping code so we can consume the soljson format which `solc-bin` provides without the cost of a second, separate `require` of the node_modules installed solc
+ Started cacheing dockerized solc version strings so we don't repeatedly query docker about its existence and type - it takes a while to spin up, especially on mac. 